### PR TITLE
Auto-update runner on start of the container, before config.sh and before before it has a chance to pick up a job (to not let this job being abandoned during the upgrade)

### DIFF
--- a/docker/ci-runner/Dockerfile
+++ b/docker/ci-runner/Dockerfile
@@ -1,8 +1,6 @@
 ARG BASE_IMAGE="ubuntu:22.04"
 FROM $BASE_IMAGE
 
-ARG RUNNER_VERSION="2.314.1"
-
 ENV GH_TOKEN=""
 ENV GH_REPOSITORY=""
 ENV GH_LABELS=""
@@ -34,7 +32,8 @@ RUN true \
       aarch64|arm64) arch=linux-arm64 ;; \
       *) echo >&2 "unsupported architecture: $arch"; exit 1 ;; \
     esac \
-    && curl --no-progress-meter -L https://github.com/actions/runner/releases/download/v$RUNNER_VERSION/actions-runner-$arch-$RUNNER_VERSION.tar.gz | tar xz
+    && runner_version=$(curl --silent "https://api.github.com/repos/actions/runner/releases/latest" | jq -r ".tag_name[1:]") \
+    && curl --no-progress-meter -L https://github.com/actions/runner/releases/download/v$runner_version/actions-runner-$arch-$runner_version.tar.gz | tar xz
 
 USER root
 RUN true \

--- a/docker/ci-runner/guest/entrypoint.03-update.sh
+++ b/docker/ci-runner/guest/entrypoint.03-update.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Upgrades-over the runner manually on each start and use --disableupdate in
+# config.sh. If we rely on the automatic upgrade during run.sh is running, then
+# it could kill jobs picked up and then abandoned due to the upgrade process.
+#
+set -u -e
+
+cd ~/actions-runner
+
+arch=$(dpkg --print-architecture)
+case "$arch" in
+  x86_64|amd64) arch=linux-x64 ;;
+  aarch64|arm64) arch=linux-arm64 ;;
+  *) echo >&2 "unsupported architecture: $arch"; exit 1 ;;
+esac
+runner_version=$(curl --silent "https://api.github.com/repos/actions/runner/releases/latest" | jq -r ".tag_name[1:]")
+curl --no-progress-meter -L "https://github.com/actions/runner/releases/download/v$runner_version/actions-runner-$arch-$runner_version.tar.gz" | tar xz
+
+echo "Updated runner to $runner_version"

--- a/docker/ci-runner/guest/entrypoint.05-config.sh
+++ b/docker/ci-runner/guest/entrypoint.05-config.sh
@@ -43,6 +43,7 @@ token=$(gh api -X POST --jq .token "repos/$GH_REPOSITORY/actions/runners/registr
   --name "$name" \
   --labels "$GH_LABELS" \
   --work /mnt \
+  --disableupdate \
   --replace
 
 cleanup() {


### PR DESCRIPTION


## PRs in the Stack
- ➡ #12

(The stack is managed by [git-grok](https://github.com/dimikot/git-grok).)
