### PR TITLE
Make runner container compatible with sysbox (for dind)

### DIFF
--- a/docker/ci-runner/Dockerfile
+++ b/docker/ci-runner/Dockerfile
@@ -13,22 +13,24 @@ ENV DEBUG_SHUTDOWN_DELAY_SEC=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Register official Docker repo.
-RUN true \
-    && apt-get update -y \
-    && apt-get install -y lsb-release ca-certificates curl \
-    && install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
-    && chmod a+r /etc/apt/keyrings/docker.asc \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
-
-# Install all needed packages.
+# Install essential packages.
 RUN true \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
       openssh-client \
-      docker-ce-cli awscli build-essential haproxy rinetd \
-      jq gh rsync python3 rsyslog systemctl tzdata gosu less mc git curl wget pv psmisc unzip vim nano telnet net-tools apt-transport-https ca-certificates locales gnupg
+      awscli build-essential haproxy rinetd \
+      jq gh rsync python3 rsyslog systemctl tzdata gosu less mc git curl wget pv psmisc unzip vim nano telnet net-tools apt-transport-https ca-certificates locales gnupg lsb-release
+
+# Install & patch Docker-in-Docker service. Requires sysbox installed on the host. See also:
+# https://forums.docker.com/t/etc-init-d-docker-62-ulimit-error-setting-limit-invalid-argument-problem/139424
+RUN true \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends docker-ce docker-ce-cli containerd.io docker-compose-plugin \
+    && sed -i -e "s/ulimit -Hn/ulimit -n/" /etc/init.d/docker
 
 # Add user "guest".
 RUN true \

--- a/docker/ci-runner/root/entrypoint.02-permissions.sh
+++ b/docker/ci-runner/root/entrypoint.02-permissions.sh
@@ -7,7 +7,3 @@ set -u -e
 chown guest:guest /mnt
 
 chmod 700 /mnt
-
-if [[ -e /var/run/docker.sock ]]; then
-  chown root:guest /var/run/docker.sock
-fi

--- a/docker/ci-runner/root/entrypoint.60-dind.sh
+++ b/docker/ci-runner/root/entrypoint.60-dind.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Optionally run Docker-in-Docker service.
+# Requires sysbox installed on the host.
+#
+set -u -e
+
+# We use the init script and not systemd, because containerd's systemctl script
+# tries to modprobe, fails and shows a nasty warning.
+/etc/init.d/docker start
+echo
+
+dind_loop() {
+  for _n in {0..9}; do
+    if ! pgrep dockerd >/dev/null; then
+      log=/var/log/docker.log
+      echo
+      echo "Warning: Docker-in-Docker died; we still continue though."
+      echo "- Maybe sysbox is not installed on the host system?"
+      echo "- Or maybe you run this container on a Docker Desktop host?"
+      echo "Logs from $log:"
+      tail -n 5 $log | sed -E "s/^ +//" | grep . || true
+      echo
+      break
+    fi
+    sleep 1
+  done
+}
+
+dind_loop &

--- a/docker/ci-storage/Dockerfile
+++ b/docker/ci-storage/Dockerfile
@@ -6,11 +6,12 @@ ENV TZ=""
 # SECRET: CI_STORAGE_PUBLIC_KEY
 
 ENV DEBIAN_FRONTEND=noninteractive
+
 RUN true \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
       openssh-server \
-      jq gh rsync python3 rsyslog systemctl tzdata gosu less mc git curl wget pv psmisc unzip vim nano telnet net-tools apt-transport-https ca-certificates locales gnupg \
+      jq gh rsync python3 rsyslog systemctl tzdata gosu less mc git curl wget pv psmisc unzip vim nano telnet net-tools apt-transport-https ca-certificates locales gnupg lsb-release \
     && sed -i -e "s|#PermitRootLogin.*|PermitRootLogin no|" /etc/ssh/sshd_config \
     && useradd -m guest -s /bin/bash \
     && mkdir ~guest/.ssh && chmod 700 ~guest/.ssh \

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -41,9 +41,6 @@ services:
       - CI_STORAGE_PRIVATE_KEY
     tmpfs:
       - /mnt:exec
-    volumes:
-      # Allow running docker from inside the container (optional).
-      - /var/run/docker.sock:/var/run/docker.sock
 
 secrets:
   CI_STORAGE_PUBLIC_KEY:


### PR DESCRIPTION
Passing docker.sock inside of the runner's container is not an option: it doesn't allow to mount directories from the container into the newly created "sibling" containers (since mounting this way always targets the filesystem of the host). So in this mode, CI jobs which use "docker run" by themselves won't work.

Instead, we now rely on [sysbox](https://github.com/nestybox/sysbox/tree/master) installed on the host, which allows to launch a complete Docker-in-Docker.

## PRs in the Stack
- ➡ #16

(The stack is managed by [git-grok](https://github.com/dimikot/git-grok).)
