### PR TITLE
Encourage people mount ci-runner container's /mnt (work dir) on tmpfs, and don't associate ci-storage container's /mnt with tmpfs per se

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
         uses: ./
         with:
           action: store
-          storage-dir: ~/mnt
+          storage-dir: ~/storage-dir
       - name: Test store (layer)
         uses: ./
         with:
           action: store
-          storage-dir: ~/mnt
+          storage-dir: ~/storage-dir
           layer-name: my-layer
           layer-include: layer.txt
       - name: Remove dummy file
@@ -51,11 +51,11 @@ jobs:
         uses: ./
         with:
           action: load
-          storage-dir: ~/mnt
+          storage-dir: ~/storage-dir
       - name: Check that dummy.txt was restored
         run: |
           set -e
-          ls -la ~/mnt/${{ github.repository }}
+          ls -la ~/storage-dir/${{ github.repository }}
           [[ "$(cat dummy.txt)" == "dummy" ]] || { echo "dummy.txt must be restored"; exit 1; }
       - name: Remove layer.txt file and dir/subdir hierarchy
         run: rm -rf dir
@@ -63,12 +63,12 @@ jobs:
         uses: ./
         with:
           action: load
-          storage-dir: ~/mnt
+          storage-dir: ~/storage-dir
           layer-name: my-layer
       - name: Check that dir/subdir/layer.txt was restored, and dummy.txt still exists
         run: |
           set -e
-          ls -la ~/mnt/${{ github.repository }}.my-layer
+          ls -la ~/storage-dir/${{ github.repository }}.my-layer
           [[ "$(cat dummy.txt)" == "dummy" ]] || { echo "dummy.txt must be kept"; exit 1; }
           [[ "$(cat dir/subdir/layer.txt)" == "layer" ]] || { echo "layer.txt must be restored"; exit 1; }
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ ones, so rsync can run efficiently.
     storage-host: ''
 
     # Storage directory on the storage host.
-    # Default: /mnt/{owner}/{repo} in the storage host's user home.
+    # Default: /mnt/{owner}/{repo}.
     storage-dir: ''
 
     # Remove slots created earlier than this many seconds ago.

--- a/docker/ci-runner/README.md
+++ b/docker/ci-runner/README.md
@@ -66,14 +66,13 @@ services:
       # An address of ci-storage service to pull the slots from.
       - CI_STORAGE_HOST=127.0.0.1:10022
     volumes:
-      # Makes the content of /mnt survive container re-creation on upgrades.
-      - ci-runner-mnt:/mnt
       # ~/.ssh/ci-storage must exist on the docker host to access ci-storage
       # remote container at $FORWARD_HOST
       - ~/.ssh/ci-storage:/run/secrets/CI_STORAGE_PRIVATE_KEY
-volumes:
-  ci-runner-mnt:
-    external: false
+    tmpfs:
+      # Having work directory on tmpfs makes latency predictable, which is very
+      # handy while debugging the CI perf bottlenecks.
+      - /mnt:exec
 ```
 
 Example for your custom Dockerfile mentioned above. This Dockerfile allows to
@@ -90,7 +89,6 @@ RUN true \
 COPY --chmod=755 --chown=root:root root/entrypoint*.sh /root
 COPY --chmod=755 --chown=guest:guest guest/entrypoint*.sh /home/guest
 ```
-
 
 The container in this Dockerfile serves only one particular GitHub repository
 (controlled by `GH_REPOSITORY` environment variable at boot time). To serve

--- a/docker/ci-runner/guest/entrypoint.01-ci-storage-load.sh
+++ b/docker/ci-runner/guest/entrypoint.01-ci-storage-load.sh
@@ -6,13 +6,13 @@ set -u -e
 
 echo "$CI_STORAGE_HOST" > ci-storage-host
 
-local_dir=/mnt/${GH_REPOSITORY##*/}/${GH_REPOSITORY##*/}
+local_dir=$WORK_DIR/${GH_REPOSITORY##*/}/${GH_REPOSITORY##*/}
 
 if [[ "$CI_STORAGE_HOST" != "" && -f ~/.ssh/id_rsa ]]; then
   mkdir -p "$local_dir"
   ci-storage load \
     --storage-host="$CI_STORAGE_HOST" \
-    --storage-dir="/mnt/$GH_REPOSITORY" \
+    --storage-dir="$WORK_DIR/$GH_REPOSITORY" \
     --slot-id="*" \
     --local-dir="$local_dir"
 fi

--- a/docker/ci-runner/guest/entrypoint.05-config.sh
+++ b/docker/ci-runner/guest/entrypoint.05-config.sh
@@ -42,7 +42,7 @@ token=$(gh api -X POST --jq .token "repos/$GH_REPOSITORY/actions/runners/registr
   --token "$token" \
   --name "$name" \
   --labels "$GH_LABELS" \
-  --work /mnt \
+  --work "$WORK_DIR" \
   --disableupdate \
   --replace
 

--- a/docker/ci-runner/root/entrypoint.00-helpers.sh
+++ b/docker/ci-runner/root/entrypoint.00-helpers.sh
@@ -4,6 +4,9 @@
 #
 set -u -e
 
+# GitHub Runner's work directory (encouraged to be mounted on tmpfs).
+export WORK_DIR="/mnt"
+
 # We don't use ec2metadata CLI tool, because it does not allow to configure
 # timeout. In case the container is run outside of AWS infra (e.g. during local
 # development), the absense of timeout causes problems.

--- a/docker/ci-runner/root/entrypoint.02-permissions.sh
+++ b/docker/ci-runner/root/entrypoint.02-permissions.sh
@@ -4,6 +4,5 @@
 #
 set -u -e
 
-chown guest:guest /mnt
-
-chmod 700 /mnt
+chown guest:guest "$WORK_DIR"
+chmod 700 "$WORK_DIR"

--- a/docker/ci-runner/root/entrypoint.70-prewarm.sh
+++ b/docker/ci-runner/root/entrypoint.70-prewarm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Prints usage statistics and also, if /mnt is not on tmpfs, keeps the directory
+# Prints usage statistics and also, if work directory is not on tmpfs, keeps it
 # in cache to lower the chances of the directory entries to be evicted.
 #
 set -u -e
@@ -9,11 +9,10 @@ prewarm_loop() {
   sleep 30
   while :; do
     time_took=/tmp/time_took
-    mnt=/mnt
     export TIMEFORMAT="%R sec"
-    info=$({ time df -h --output=fstype,target,used $mnt | tail -n1 | sed -E 's/[[:space:]]+/ /g'; } 2>$time_took)
+    info=$({ time df -h --output=fstype,target,used "$WORK_DIR" | tail -n1 | sed -E 's/[[:space:]]+/ /g'; } 2>$time_took)
     if [[ "$info" != *tmpfs* ]]; then
-      info=$({ time du -sh $mnt | sed -E 's/\s+/ /g'; } 2>$time_took)
+      info=$({ time du -sh "$WORK_DIR" | sed -E 's/\s+/ /g'; } 2>$time_took)
     fi
     uptime=$(uptime | sed -E -e 's/^\s*[0-9:]+\s+//' -e 's/\s+/ /g')
     echo "$(nice_date): Prewarm (took $(cat $time_took)): $info: $uptime"

--- a/docker/ci-scaler/README.md
+++ b/docker/ci-scaler/README.md
@@ -38,4 +38,10 @@ services:
 
 One ci-scaler container may serve multiple GitHub repositories.
 
+To enter the container, run e.g.:
+
+```
+docker compose exec ci-scaler bash -l
+```
+
 See also https://github.com/dimikot/ci-storage

--- a/docker/ci-storage/README.md
+++ b/docker/ci-storage/README.md
@@ -11,8 +11,8 @@ infra. This server is needed for ci-storage tool to work.
    - `CI_STORAGE_PUBLIC_KEY` (optional): pass this secret or mount a file from
      host to `/run/secrets/CI_STORAGE_PUBLIC_KEY` to allow SSH access to this
      host from any ci-runner container which knows its private key
-4. Mount some persistent storage (e.g. a EBS volume) to `/mnt`, so it survives
-   the container restart.
+4. Optionally, mount some persistent volume to the storage directory, so it will
+   survive the container restart.
 
 Example for docker compose:
 
@@ -37,6 +37,12 @@ volumes:
 ```
 
 One ci-storage container may serve multiple GitHub repositories. Each of them
-will have own directory in /mnt (managed by ci-storage tool).
+will have its own sub-directory (managed by ci-storage tool).
+
+To enter the container, run e.g.:
+
+```
+docker compose exec ci-storage bash -l
+```
 
 See also https://github.com/dimikot/ci-storage

--- a/docker/ci-storage/root/entrypoint.00-helpers.sh
+++ b/docker/ci-storage/root/entrypoint.00-helpers.sh
@@ -4,6 +4,9 @@
 #
 set -u -e
 
+# Storage directory where ci-storage tool saves the data.
+export STORAGE_DIR="/mnt"
+
 # Prints the current date in the same format as the GitHub Actions runner does.
 nice_date() {
   date +"%Y-%m-%d %H:%M:%S %Z"

--- a/docker/ci-storage/root/entrypoint.02-permissions.sh
+++ b/docker/ci-storage/root/entrypoint.02-permissions.sh
@@ -4,5 +4,5 @@
 #
 set -u -e
 
-chown guest:guest /mnt
-chmod 700 /mnt
+chown guest:guest "$STORAGE_DIR"
+chmod 700 "$STORAGE_DIR"

--- a/docker/ci-storage/root/entrypoint.70-prewarm.sh
+++ b/docker/ci-storage/root/entrypoint.70-prewarm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Prints usage statistics and also, if /mnt is not on tmpfs, keeps the directory
-# in cache to lower the chances of the directory entries to be evicted.
+# Prints usage statistics and also, if the storage directory is not on tmpfs,
+# keeps it in cache to lower the chances of the directory entries to be evicted.
 #
 set -u -e
 
@@ -9,11 +9,10 @@ prewarm_loop() {
   sleep 30
   while :; do
     time_took=/tmp/time_took
-    mnt=/mnt
     export TIMEFORMAT="%R sec"
-    info=$({ time df -h --output=fstype,target,used $mnt | tail -n1 | sed -E 's/[[:space:]]+/ /g'; } 2>$time_took)
+    info=$({ time df -h --output=fstype,target,used "$STORAGE_DIR" | tail -n1 | sed -E 's/[[:space:]]+/ /g'; } 2>$time_took)
     if [[ "$info" != *tmpfs* ]]; then
-      info=$({ time du -sh $mnt | sed -E 's/\s+/ /g'; } 2>$time_took)
+      info=$({ time du -sh "$STORAGE_DIR" | sed -E 's/\s+/ /g'; } 2>$time_took)
     fi
     uptime=$(uptime | sed -E -e 's/^\s*[0-9:]+\s+//' -e 's/\s+/ /g')
     echo "$(nice_date): Prewarm (took $(cat $time_took)): $info: $uptime"

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,3 +1,8 @@
+#
+# This compose.yml file is used for local testing. You can also use it as a
+# template for your own deployment. See also README.md files with more examples.
+#
+
 services:
   ci-scaler:
     build:
@@ -31,10 +36,10 @@ services:
       - 10022:22
     environment:
       - TZ
+    volumes:
+      - ci-storage-mnt:/mnt
     secrets:
       - CI_STORAGE_PUBLIC_KEY
-    tmpfs:
-      - /mnt:exec
 
   ci-runner:
     build:
@@ -59,6 +64,10 @@ services:
       - CI_STORAGE_PRIVATE_KEY
     tmpfs:
       - /mnt:exec
+
+volumes:
+  ci-storage-mnt:
+    external: false
 
 secrets:
   CI_STORAGE_PUBLIC_KEY:


### PR DESCRIPTION
The idea is:

- For runners, their /mnt dir will be mounted to tmpfs with native docker compose tools on the instance (i.e. the instance itself doesn't mount anything special on tmpfs).
- For ci-storage on host instance, the entire /var/lib/docker will be on its tmpfs (and migrated when the instance gets replaced), so we don't need to associate /mnt with tmpfs comceptually.

## PRs in the Stack
- ➡ #20

(The stack is managed by [git-grok](https://github.com/dimikot/git-grok).)
