### PR TITLE
Improve dedupping probability on load+store

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,13 @@
   "cSpell.words": [
     "asgs",
     "BTIME",
+    "dedup",
     "dedupping",
     "digestmod",
     "elif",
+    "hardlink",
     "mtimes",
+    "myslot",
     "tmpfs"
   ]
 }

--- a/ci-storage
+++ b/ci-storage
@@ -147,6 +147,7 @@ def main():
         action_store(
             storage_host=storage_host,
             storage_dir=storage_dir,
+            storage_max_age_sec=storage_max_age_sec,
             slot_id=slot_ids[0],
             local_dir=local_dir,
             exclude=exclude,
@@ -156,7 +157,7 @@ def main():
         action_maintenance(
             storage_host=storage_host,
             storage_dir=storage_dir,
-            max_age_sec=storage_max_age_sec,
+            storage_max_age_sec=storage_max_age_sec,
         )
     if action == "load":
         if not slot_ids:
@@ -286,6 +287,7 @@ def action_store(
     *,
     storage_host: str | None,
     storage_dir: str,
+    storage_max_age_sec: int,
     slot_id: str,
     local_dir: str,
     exclude: list[str],
@@ -297,16 +299,27 @@ def action_store(
         raise UserException(f'slot_id="{slot_id}" is not allowed for "store" action')
 
     meta = None
+    slot_id_we_used_to_load_from = None
     if not layer:
         meta = SlotMeta.read_from(local_dir=local_dir)
-        meta.full_snapshot_history.insert(0, slot_id)
+        if meta and meta.full_snapshot_history:
+            slot_id_we_used_to_load_from = meta.full_snapshot_history[0]
 
     slot_infos = list_slots(
         storage_host=storage_host,
         storage_dir=storage_dir,
     )
 
-    slot_recent = list(slot_infos.values())[0] if slot_infos else None
+    slot_recent = None
+    if (
+        slot_id_we_used_to_load_from in slot_infos
+        and slot_infos[slot_id_we_used_to_load_from].age_sec
+        < storage_max_age_sec - STORAGE_MAX_AGE_SEC_BAK
+    ):
+        slot_recent = slot_infos[slot_id_we_used_to_load_from]
+    elif slot_infos:
+        slot_recent = list(slot_infos.values())[0]
+
     slot_id_tmp = f"{slot_id}.tmp.{int(time.time())}"
     host, port = parse_host_port(storage_host)
     check_call(
@@ -328,6 +341,10 @@ def action_store(
         print_elapsed=True,
     )
 
+    if meta:
+        meta.full_snapshot_history.insert(0, slot_id)
+        meta.write_to(local_dir=local_dir)
+
     print(
         check_output_script(
             host=storage_host,
@@ -343,9 +360,6 @@ def action_store(
         end="",
     )
 
-    if meta:
-        meta.write_to(local_dir=local_dir)
-
 
 #
 # Runs the maintenance script for the storage.
@@ -354,13 +368,13 @@ def action_maintenance(
     *,
     storage_host: str | None,
     storage_dir: str,
-    max_age_sec: int,
+    storage_max_age_sec: int,
 ):
     print(
         check_output_script(
             host=storage_host,
             script=SCRIPTS["MAINTENANCE"],
-            args=[storage_dir, str(max_age_sec)],
+            args=[storage_dir, str(storage_max_age_sec)],
             indent=True,
         ),
         end="",
@@ -390,7 +404,7 @@ def list_slots(
             slot_id = match.group(1)
             slot_infos[slot_id] = SlotInfo(
                 id=slot_id,
-                age=int(match.group(2)),
+                age_sec=int(match.group(2)),
                 meta=SlotMeta.deserialize(
                     match.group(3).encode().decode("unicode_escape")
                 ),
@@ -673,7 +687,7 @@ class SlotMeta:
 @dataclasses.dataclass
 class SlotInfo:
     id: str
-    age: int
+    age_sec: int
     meta: SlotMeta
 
 
@@ -812,7 +826,7 @@ SCRIPTS = {
         *STDOUT->autoflush(1);
         *STDERR->autoflush(1);
         my $storage_dir = $ARGV[0] or die("storage_dir argument required\n");
-        my $max_age_sec = $ARGV[1] or die("max_age_sec argument required\n");
+        my $storage_max_age_sec = $ARGV[1] or die("storage_max_age_sec argument required\n");
         length($storage_dir) >= 3 or die("storage_dir is suspiciously short\n");
         my $lock_file = "$storage_dir/maintenance.lock";
         open(my $lock, ">>", $lock_file) or die("open $lock_file: $!\n");
@@ -832,7 +846,10 @@ SCRIPTS = {
                 # Never delete the latest slot, even if it is old.
                 next;
             }
-            if ($age_sec > $max_age_sec || $is_bak && $age_sec > %(STORAGE_MAX_AGE_SEC_BAK)d) {
+            if (
+                $age_sec > $storage_max_age_sec ||
+                $is_bak && $age_sec > %(STORAGE_MAX_AGE_SEC_BAK)d
+            ) {
                 push(@rm_dirs, $dir);
                 print("will remove $dir (age: $age_sec sec) in background\n");
             }

--- a/docker/ci-scaler/guest/scaler/helpers.py
+++ b/docker/ci-scaler/guest/scaler/helpers.py
@@ -248,7 +248,7 @@ class PostJsonHttpRequestHandler(http.server.BaseHTTPRequestHandler):
     sys_version = "1.0"
     log_suffix = ""
 
-    def handle_POST_json(self, data: dict[str, Any], data_bytes: bytes) -> None:
+    def handle_POST_json(self, data: Any, data_bytes: bytes) -> None:
         self.send_error(404, "No handler for POST request overridden")
         pass
 

--- a/tests/0015-load-then-store-dedups-with-loaded-slot.test.sh
+++ b/tests/0015-load-then-store-dedups-with-loaded-slot.test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+source ./common.sh
+
+touch "$LOCAL_DIR/file"
+ci-storage --slot-id="myslot1-early" store
+sleep 1
+
+touch "$LOCAL_DIR/file"
+ci-storage --slot-id="myslot2-middle" store
+sleep 1
+
+# After loading from myslot1-early slot...
+ci-storage --slot-id="myslot1-early" load
+grep -qF 'Checking slot-id="myslot1-early"... found in the storage, using it' "$OUT"
+
+# ...we should use the same myslot1-early as a value for --link-dest as well
+# (NOT the most recent slot myslot2-middle).
+ci-storage --slot-id="myslot3-late" store
+grep -qF -- '--link-dest=../myslot1-early/' "$OUT"
+
+# Check hard-link counts: we should dedup myslot1-early with myslot3-late.
+test "$(hardlink-count "$STORAGE_DIR/myslot1-early/file")" == 2
+test "$(hardlink-count "$STORAGE_DIR/myslot2-middle/file")" == 1
+test "$(hardlink-count "$STORAGE_DIR/myslot3-late/file")" == 2
+
+# Just in case, load from myslot3-late, and since it has been dedupped with
+# myslot1-early, they should all dedup between each other.
+ci-storage --slot-id="*" load
+grep -qF 'Checking slot-id="*"... using the most recent slot-id="myslot3-late"' "$OUT"
+
+ci-storage --slot-id="myslot4-end" store
+grep -qF -- '--link-dest=../myslot3-late/' "$OUT"
+test "$(hardlink-count "$STORAGE_DIR/myslot1-early/file")" == 3
+test "$(hardlink-count "$STORAGE_DIR/myslot2-middle/file")" == 1
+test "$(hardlink-count "$STORAGE_DIR/myslot3-late/file")" == 3
+test "$(hardlink-count "$STORAGE_DIR/myslot4-end/file")" == 3

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -4,7 +4,7 @@ set -e -o pipefail
 # shellcheck disable=SC2154
 trap '
   exitcode=$?
-  set +o xtrace
+  { set +o xtrace; } 2>/dev/null
   if [[ "$exitcode" != 0 ]]; then
     echo
     echo "FAILED! Last output was:"
@@ -30,6 +30,13 @@ touch $LOCAL_DIR/dir-a/file-a-1
 
 ci-storage() {
   ../ci-storage --local-dir="$LOCAL_DIR" --storage-dir="$STORAGE_DIR" "$@" &>$OUT
+}
+
+hardlink-count() {
+  { set +o xtrace; } 2>/dev/null
+  # shellcheck disable=SC2012
+  ls -l "$1" | awk '{print $2}'
+  { set -o xtrace; } 2>/dev/null
 }
 
 set -x


### PR DESCRIPTION
Use case: we load from some non-recent slot "EARLY", do something which doesn't change the files, and then store to the slot "LATE".

Previously, when rsyncing-out to slot "LATE", we tried to hardlink-dedup with the **most recent** slot on ci-storage end (let's name it "MIDDLE"). The problem is that, since we actually loaded not from the most recent "MIDDLE" slot, but from another ("EARLY") slot, then, when storing, we didn't get optimal hardlink-dedupping, because unchanged files in "LATE" are technically compared with "MIDDLE" and not with "EARLY" data, where they did originate from.

What's funny is that we store the real loading history in the slot meta, but we did not use it here.

In this PR, the history info starts being used to detect the best slot to dedup with ("EARLY" in the above example). I.e. if we loaded from somewhere, then we try to dedup with that exact "somewhere" when storing.

## PRs in the Stack
- ➡ #31

(The stack is managed by [git-grok](https://github.com/dimikot/git-grok).)
